### PR TITLE
Fix collection by album

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ Rdio2Spotify
 Copies playlists and collection tracks/albums from Rdio to Spotify.
 
 Edit main.py, setting [Rdio API](http://www.rdio.com/developers/your-apps/) and [Spotify API](https://developer.spotify.com/my-applications) credentials in the first four variables.
-The Rdio and Spotify API apps must have http://localhost:8123/ in their list of redirect URIs.  After pasting the OAuth links printed to the terminal into your browser, retrun to the terminal when the authentication finishes.
+The Rdio and Spotify API apps must have http://127.0.0.1:8123/ in their list of redirect URIs.  After pasting the OAuth links printed to the terminal into your browser, retrun to the terminal when the authentication finishes.

--- a/main.py
+++ b/main.py
@@ -24,7 +24,7 @@ def normalize_text(data):
 
 
 def get_sessions():
-    redirect_uri = 'http://localhost:%d/' % redirect_port
+    redirect_uri = 'http://127.0.0.1:%d/' % redirect_port
     class Handler(BaseHTTPServer.BaseHTTPRequestHandler):
         code = None
 

--- a/main.py
+++ b/main.py
@@ -239,7 +239,7 @@ def sync_followed_artists(rdio_session, spotify_session):
 def sync_collection_albums(rdio_session, spotify_session):
     print 'Syncing collection albums'
 
-    albums = rdio_session.post('', data={'method': 'getAlbumsInCollection', 'count': page_size}, verify=True)
+    albums = rdio_session.post('', data={'method': 'getAlbumsInCollection', 'count': page_size, 'start': 0}, verify=True)
 
     if albums.status_code != 200:
         print albums.json()
@@ -291,7 +291,7 @@ def sync_collection_albums(rdio_session, spotify_session):
 
         retries = 1
         while retries < 10:
-            albums = rdio_session.post('', data={'method': 'getAlbumsInCollection', 'count': page_size*search_loop}, verify=True)
+            albums = rdio_session.post('', data={'method': 'getAlbumsInCollection', 'count': page_size, 'start': page_size*search_loop}, verify=True)
             if albums.status_code == 200:
                 break
             retries = retries + 1


### PR DESCRIPTION
I was trying to migrate my collection using the 'sync_collection_albums' option. Requests kept timing out around 800 albums. Then I realized it was because the original script selects larger and larger counts of albums.

This modifies the script to select a count of `page_size`, but start at a different offset.

I also updated the script and readme to change `localhost` to `127.0.0.1`.  Rdio seems to think that localhost is a bad redirect URI.
